### PR TITLE
Update Delegated OAuth to 1.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"require": {
 		"php": ">=7.1",
 		"humanmade/wp-simple-saml": "0.4",
-		"humanmade/delegated-oauth": "1.0.1"
+		"humanmade/delegated-oauth": "1.0.2"
 	},
 	"extra": {
 		"altis": {}


### PR DESCRIPTION
Seeing as we control this, we could use a `~` here?