### PR TITLE
Refresh login form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 	],
 	"autoload": {
 		"files": [
+			"inc/namespace.php",
 			"inc/saml/namespace.php",
 			"inc/wordpress/namespace.php"
 		]

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,20 @@ The SSO module allows you to delegate the authorization and user management of y
 The SSO module provides built in support for popular authorization protocols. The implementation of the authorization client all work in mostly the same way. The SSO provider is used to authenticate a user, typically via a web redirect. Once the user has authenticated, they are redirected back to the Altis application, where their user record is imported into the CMS.
 
 Once the CMS has a user record in the database, the user's session is authorized and logged in to that account. Any user operations from that point on are treating as regular CMS user operations, against the local "mirrored" user record.
+
+Supported authorization providers are:
+
+* [SAML 2.0](./saml-2-0.md)
+* [WordPress](./wordpress.md)
+
+## Hiding native login
+
+If you're using a single sign-on provider, you may wish to hide the regular WordPress username and password options from the login screen. This can be configured with the `hide_native` configuration option:
+
+```json
+"sso": {
+	"hide_native": true
+}
+```
+
+Note: This will only disable the visual display of the login form. Username and password authentication cannot be disabled.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -37,6 +37,16 @@ function is_sso_active() : bool {
 }
 
 /**
+ * Check whether native (WordPress) login should be hidden.
+ *
+ * @return bool True if the native login form should be hidden, false otherwise.
+ */
+function is_native_hidden() : bool {
+	$config = Altis\get_config()['modules']['sso'];
+	return $config['hide_native'] ?? false;
+}
+
+/**
  * Output the single sign-on buttons on the login form.
  *
  * Also handles restyling the form.
@@ -45,7 +55,9 @@ function output_sso_buttons() : void {
 	$config = Altis\get_config()['modules']['sso'];
 	?>
 	<div class="altis-sso-options">
-		<div class="altis-sso-sep"><?php esc_html_e( 'or', 'altis' ) ?></div>
+		<?php if ( ! is_native_hidden() ): ?>
+			<div class="altis-sso-sep"><?php esc_html_e( 'or', 'altis' ) ?></div>
+		<?php endif; ?>
 
 		<?php if ( $config['saml'] ): ?>
 			<?php SAML\render_login_link() ?>
@@ -86,6 +98,16 @@ function output_sso_buttons() : void {
 			width: 100%;
 			text-align: center;
 		}
+
+		<?php if ( is_native_hidden() ): ?>
+			#loginform > :first-child,
+			#loginform .user-pass-wrap,
+			#loginform .forgetmenot,
+			#loginform .submit,
+			#nav {
+				display: none;
+			}
+		<?php endif; ?>
 	</style>
 	<?php
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Altis\SSO;
+
+use Altis;
+
+/**
+ * Bootstrap the SSO module.
+ */
+function bootstrap() {
+	if ( ! is_sso_active() ) {
+		return;
+	}
+
+	$config = Altis\get_config()['modules']['sso'];
+	if ( $config['saml'] ) {
+		SAML\bootstrap();
+	}
+	if ( $config['wordpress'] ) {
+		WordPress\bootstrap();
+	}
+
+	add_action( 'login_form', __NAMESPACE__ . '\\output_sso_buttons' );
+}
+
+/**
+ * Check whether any SSO solution is active.
+ *
+ * @return bool True if any SSO provider is active, false otherwise.
+ */
+function is_sso_active() : bool {
+	$config = Altis\get_config()['modules']['sso'];
+	if ( $config['saml'] || $config['wordpress'] ) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Output the single sign-on buttons on the login form.
+ *
+ * Also handles restyling the form.
+ */
+function output_sso_buttons() : void {
+	$config = Altis\get_config()['modules']['sso'];
+	?>
+	<div class="altis-sso-options">
+		<div class="altis-sso-sep"><?php esc_html_e( 'or', 'altis' ) ?></div>
+
+		<?php if ( $config['saml'] ): ?>
+			<?php SAML\render_login_link() ?>
+		<?php endif; ?>
+
+		<?php if ( $config['wordpress'] ): ?>
+			<?php WordPress\render_login_link() ?>
+		<?php endif; ?>
+	</div>
+	<style>
+		#loginform {
+			display: flex;
+			flex-direction: column;
+		}
+		.altis-sso-options {
+			order: 100;
+			display: flex;
+			flex-direction: column;
+			align-items: stretch;
+			row-gap: 0.5em;
+		}
+		.altis-sso-sep {
+			text-transform: uppercase;
+			display: flex;
+			height: 1.5em;
+			column-gap: 1em;
+			margin: 1em 0;
+		}
+		.altis-sso-sep::before,
+		.altis-sso-sep::after {
+			display: block;
+			content: "";
+			border-bottom: 1px solid #f0f0f1;
+			flex: 1;
+			height: 0.7em;
+		}
+		.altis-sso-options .button {
+			width: 100%;
+			text-align: center;
+		}
+	</style>
+	<?php
+}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Altis SSO.
+ *
+ * @package altis/sso
+ */
 
 namespace Altis\SSO;
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -55,15 +55,15 @@ function output_sso_buttons() : void {
 	$config = Altis\get_config()['modules']['sso'];
 	?>
 	<div class="altis-sso-options">
-		<?php if ( ! is_native_hidden() ): ?>
+		<?php if ( ! is_native_hidden() ) : ?>
 			<div class="altis-sso-sep"><?php esc_html_e( 'or', 'altis' ) ?></div>
 		<?php endif; ?>
 
-		<?php if ( $config['saml'] ): ?>
+		<?php if ( $config['saml'] ) : ?>
 			<?php SAML\render_login_link() ?>
 		<?php endif; ?>
 
-		<?php if ( $config['wordpress'] ): ?>
+		<?php if ( $config['wordpress'] ) : ?>
 			<?php WordPress\render_login_link() ?>
 		<?php endif; ?>
 	</div>
@@ -99,7 +99,7 @@ function output_sso_buttons() : void {
 			text-align: center;
 		}
 
-		<?php if ( is_native_hidden() ): ?>
+		<?php if ( is_native_hidden() ) : ?>
 			#loginform > :first-child,
 			#loginform .user-pass-wrap,
 			#loginform .forgetmenot,

--- a/inc/saml/namespace.php
+++ b/inc/saml/namespace.php
@@ -91,7 +91,7 @@ function render_login_link() {
 	/**
 	 * Filters whether we should show the SSO login link in login form
 	 *
-	 * @return bool  Forces SSO authentication if true, defaults to True
+	 * @param bool $force_sso Forces SSO authentication if true, defaults to True.
 	 */
 	if ( ! apply_filters( 'wpsimplesaml_log_in_link', true ) ) {
 		return;
@@ -105,7 +105,7 @@ function render_login_link() {
 		/**
 		 * Filters the SSO login button text
 		 *
-		 * @return string Text to be used for the login button
+		 * @param string $login_button_text Text to be used for the login button.
 		 */
 		esc_html( apply_filters( 'wpsimplesaml_log_in_text', __( 'Log in with SAML SSO', 'wp-simple-saml' ) ) )
 	);

--- a/inc/saml/namespace.php
+++ b/inc/saml/namespace.php
@@ -8,6 +8,7 @@
 namespace Altis\SSO\SAML;
 
 use Altis;
+use HumanMade\SimpleSaml;
 
 /**
  * Bootstrap SAML integration.
@@ -76,4 +77,36 @@ function remove_plugin_admin_ui() {
 	remove_action( 'admin_init', 'HumanMade\\SimpleSaml\\Admin\\settings_fields' );
 	remove_action( 'wpmu_options', 'HumanMade\\SimpleSaml\\Admin\\network_settings_fields' );
 	remove_action( 'update_wpmu_options', 'HumanMade\\SimpleSaml\\Admin\\save_network_settings_fields' );
+
+	// Remove built-in login form UI.
+	remove_action( 'login_message', 'HumanMade\\SimpleSaml\\login_form_link' );
+}
+
+/**
+ * Show SSO login link in login form
+ *
+ * @action login_form
+ */
+function render_login_link() {
+	/**
+	 * Filters whether we should show the SSO login link in login form
+	 *
+	 * @return bool  Forces SSO authentication if true, defaults to True
+	 */
+	if ( ! apply_filters( 'wpsimplesaml_log_in_link', true ) ) {
+		return;
+	}
+
+	$redirect_url = SimpleSaml\get_redirection_url();
+
+	printf(
+		'<p class="altis-sso-saml"><a class="button button-hero" href="%s" id="login-via-sso">%s</a></p>',
+		esc_url( add_query_arg( 'redirect_to', urlencode( $redirect_url ), home_url( 'sso/login/' ) ) ),
+		/**
+		 * Filters the SSO login button text
+		 *
+		 * @return string Text to be used for the login button
+		 */
+		esc_html( apply_filters( 'wpsimplesaml_log_in_text', __( 'Log in with SAML SSO', 'wp-simple-saml' ) ) )
+	);
 }

--- a/inc/wordpress/namespace.php
+++ b/inc/wordpress/namespace.php
@@ -8,6 +8,7 @@
 namespace Altis\SSO\WordPress;
 
 use Altis;
+use HM\Delegated_Auth;
 
 /**
  * Set up action hooks.
@@ -16,6 +17,7 @@ use Altis;
  */
 function bootstrap() {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_plugin' );
+	add_filter( 'delegated-oauth2.login.button_markup', __NAMESPACE__ . '\\override_button_markup', 0 );
 }
 
 /**
@@ -49,4 +51,25 @@ function load_plugin() {
 	add_filter( 'delegated_oauth.sync-roles', ( empty( $config['sync-roles'] ) || ! $config['sync-roles'] ) ? '__return_false' : '__return_true' );
 
 	require_once Altis\ROOT_DIR . '/vendor/humanmade/delegated-oauth/plugin.php';
+
+	// Remove built-in login form UI.
+	remove_action( 'login_form', 'HM\\Delegated_Auth\\Cookie\\on_login_form' );
+}
+
+/**
+ * Show SSO login link in login form
+ *
+ * @action login_form
+ */
+function render_login_link() : void {
+	Delegated_Auth\Cookie\on_login_form();
+}
+
+/**
+ * Get the log in button markup, overriding Delegated OAuth's.
+ *
+ * @return string
+ */
+function override_button_markup() : string {
+	return '<p class="altis-sso-wordpress"><a class="button button-hero" href="%1$s">%2$s</a></p>';
 }

--- a/inc/wordpress/namespace.php
+++ b/inc/wordpress/namespace.php
@@ -45,7 +45,7 @@ function load_plugin() {
 	}
 
 	if ( ! defined( 'HM_DELEGATED_AUTH_LOGIN_TEXT' ) ) {
-		define( 'HM_DELEGATED_AUTH_LOGIN_TEXT', __( 'Login with WordPress SSO', 'altis' ) );
+		define( 'HM_DELEGATED_AUTH_LOGIN_TEXT', __( 'Log in with WordPress SSO', 'altis' ) );
 	}
 
 	add_filter( 'delegated_oauth.sync-roles', ( empty( $config['sync-roles'] ) || ! $config['sync-roles'] ) ? '__return_false' : '__return_true' );

--- a/inc/wordpress/namespace.php
+++ b/inc/wordpress/namespace.php
@@ -17,7 +17,7 @@ use HM\Delegated_Auth;
  */
 function bootstrap() {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_plugin' );
-	add_filter( 'delegated-oauth2.login.button_markup', __NAMESPACE__ . '\\override_button_markup', 0 );
+	add_filter( 'delegated_oauth.login.button_markup', __NAMESPACE__ . '\\override_button_markup', 0 );
 }
 
 /**

--- a/load.php
+++ b/load.php
@@ -14,6 +14,7 @@ add_action( 'altis.modules.init', function () {
 		'enabled' => true,
 		'saml' => false,
 		'wordpress' => false,
+		'hide_native' => false,
 	];
 	Altis\register_module( 'sso', __DIR__, 'SSO', $default_settings, function () {
 		require __DIR__ . '/inc/namespace.php';

--- a/load.php
+++ b/load.php
@@ -16,8 +16,5 @@ add_action( 'altis.modules.init', function () {
 		'wordpress' => false,
 		'hide_native' => false,
 	];
-	Altis\register_module( 'sso', __DIR__, 'SSO', $default_settings, function () {
-		require __DIR__ . '/inc/namespace.php';
-		bootstrap();
-	} );
+	Altis\register_module( 'sso', __DIR__, 'SSO', $default_settings, __NAMESPACE__ . '\\bootstrap' );
 } );

--- a/load.php
+++ b/load.php
@@ -11,17 +11,12 @@ use Altis;
 
 add_action( 'altis.modules.init', function () {
 	$default_settings = [
-		'enabled'   => true,
-		'saml'      => false,
+		'enabled' => true,
+		'saml' => false,
 		'wordpress' => false,
 	];
 	Altis\register_module( 'sso', __DIR__, 'SSO', $default_settings, function () {
-		$config = Altis\get_config()['modules']['sso'];
-		if ( $config['saml'] ) {
-			SAML\bootstrap();
-		}
-		if ( $config['wordpress'] ) {
-			WordPress\bootstrap();
-		}
+		require __DIR__ . '/inc/namespace.php';
+		bootstrap();
 	} );
 } );


### PR DESCRIPTION
Refreshes the styling of SSO options to be consistent and better match core's styling. Additionally, adds a `hide_native` option to hide the WP login form fields.

Before | After | Hidden Native
-- | -- | --
<img width="383" alt="Screen Shot 2021-06-14 at 12 11 51" src="https://user-images.githubusercontent.com/21655/121887067-2c377400-cd0e-11eb-9cf7-46d12d6f86f9.png"> | <img width="373" alt="Screen Shot 2021-06-14 at 12 13 01" src="https://user-images.githubusercontent.com/21655/121887075-2e99ce00-cd0e-11eb-8c69-d2e1af6a9e66.png"> | <img width="357" alt="Screen Shot 2021-06-14 at 12 44 27" src="https://user-images.githubusercontent.com/21655/121887153-46715200-cd0e-11eb-80fb-987742a5607e.png">

Requires https://github.com/humanmade/delegated-oauth2/pull/19