### PR TITLE
Update docs on SSO metadata file location and per-env handling

### DIFF
--- a/docs/saml-2-0.md
+++ b/docs/saml-2-0.md
@@ -17,7 +17,7 @@ To enable SAML 2.0 support, define the following options in the configuration fi
 						"required": true | false,
 					}
 				}
-			}
+			},
 			"environments": {
 				"development": {
 					"modules": {

--- a/docs/saml-2-0.md
+++ b/docs/saml-2-0.md
@@ -2,7 +2,9 @@
 
 The SSO module includes support for SAML 2.0 as a Service Provider. To enable SAML 2.0, you must define the `saml` setting in the Altis configuration. You'll need a copy of your SAML IdP Metadata XML too.
 
-To enabled SAML 2.0 support, define the following options in the configuration file, and provide the SAML IdP Metadata in a file:
+To generate the Service Provider metadata file from Altis, which is typically needed to setup the Identity provider application for each environment, visit [/sso/metadata/](site://sso/metadata/) to download the metadata XML file. Collect these XML files for all environments and pass it to your colleagues responsible for the SSO integration setup. You should expect back an Identity provider metadata XML file per environment.
+
+To enable SAML 2.0 support, define the following options in the configuration file, and provide the SAML IdP Metadata in a file per environment:
 
 
 ```json
@@ -13,7 +15,17 @@ To enabled SAML 2.0 support, define the following options in the configuration f
 				"sso": {
 					"saml": {
 						"required": true | false,
-						"metadata_file": ".config/sso/saml-idp-metadata.xml"
+					}
+				}
+			}
+			"environments": {
+				"development": {
+					"modules": {
+						"sso": {
+							"saml": {
+								"metadata_file": ".config/sso/saml-idp-metadata-development.xml"
+							}
+						}
 					}
 				}
 			}
@@ -24,7 +36,9 @@ To enabled SAML 2.0 support, define the following options in the configuration f
 
 The `required` setting defines whether authentication via the SAML 2.0 IdP for all users, or if it should be optional. When set to `true`, all users attempting to login to the site will be redirected to the SAML IdP for authorization. When setting this to `false`, an "SSO Login" link will be added to the login page, where users can optionally authorize with the SAML IdP.
 
-Your SAML IdP Metadata file is specified by the `metadata_file` setting, which is a path relative to your project root. By default, this is set to `.config/sso/saml-idp-metadata.xml`. Make sure there are no XML formatting errors or leading whitespeace.
+Your SAML IdP Metadata file is specified by the `metadata_file` setting, which is a path relative to your project root. By default, this is set to `.config/sso/saml-idp-metadata-%ENVIRONMENT%.xml` where `%ENVIRONMENT%` is one of `local`, `development`, `staging`, or `production`, and falls back to `.config/sso/saml-idp-metadata.xml`. Make sure there are no XML formatting errors or leading whitespeace. The setting doesn't need to be overridden if the files are in the expected location with the expected naming conventions.
+
+It is suggested to keep the default `saml-idp-metadata.xml` file for local testing, as that's used by our SSO testing instructions, or at least rename it to `.config/sso/saml-idp-metadata-local.xml`.
 
 For example:
 

--- a/docs/saml-2-0.md
+++ b/docs/saml-2-0.md
@@ -2,7 +2,7 @@
 
 The SSO module includes support for SAML 2.0 as a Service Provider. To enable SAML 2.0, you must define the `saml` setting in the Altis configuration. You'll need a copy of your SAML IdP Metadata XML too.
 
-To generate the Service Provider metadata file from Altis, which is typically needed to setup the Identity provider application for each environment, visit [/sso/metadata/](site://sso/metadata/) to download the metadata XML file. Collect these XML files for all environments and pass it to your colleagues responsible for the SSO integration setup. You should expect back an Identity provider metadata XML file per environment.
+To generate the Service Provider metadata file from Altis, which is typically needed to setup the Identity provider application for each environment, visit [`/sso/metadata/`](site://sso/metadata/) on your application to download the metadata XML file. Collect these XML files for all environments and pass it to your colleagues responsible for the SSO integration setup. You should expect back an Identity provider metadata XML file per environment.
 
 To enable SAML 2.0 support, define the following options in the configuration file, and provide the SAML IdP Metadata in a file per environment:
 

--- a/inc/saml/namespace.php
+++ b/inc/saml/namespace.php
@@ -10,8 +10,6 @@ namespace Altis\SSO\SAML;
 use Altis;
 use HumanMade\SimpleSaml;
 
-use function Altis\get_environment_type;
-
 /**
  * Bootstrap SAML integration.
  *
@@ -48,20 +46,20 @@ function get_idp_metadata_file_path() : string {
 	}
 
 	// Check for env-specific metadata files.
-	$env_file = implode( DIRECTORY_SEPARATOR, [ Altis\ROOT_DIR, '.config', 'sso', sprintf( 'saml-idp-metadata-%s.xml', get_environment_type() ) ] );
+	$env_file = Altis\ROOT_DIR . '/.config/sso/' . sprintf( 'saml-idp-metadata-%s.xml', \Altis\get_environment_type() );
 	if ( file_exists( $env_file ) ) {
 		return $env_file;
 	}
 
 	// If the legacy-style file exists, load it, but warn.
-	$legacy_file = implode( DIRECTORY_SEPARATOR, [ Altis\ROOT_DIR, 'config', 'sso', 'saml-idp-metadata.xml' ] );
+	$legacy_file = Altis\ROOT_DIR . '/config/sso/saml-idp-metadata.xml';
 	if ( file_exists( $legacy_file ) ) {
 		trigger_error( 'The default "config/sso/saml-idp-metadata.xml" path is deprecated as of Altis 2.0. Specify the metadata_file setting manually, or use the default ".config/sso/saml-idp-metadata.xml".', E_USER_DEPRECATED );
 		return $legacy_file;
 	}
 
 	// Otherwise, use the default.
-	return implode( DIRECTORY_SEPARATOR, [ Altis\ROOT_DIR, '.config', 'sso', 'saml-idp-metadata.xml' ] );
+	return Altis\ROOT_DIR . '/.config/sso/saml-idp-metadata.xml';
 }
 
 /**

--- a/inc/saml/namespace.php
+++ b/inc/saml/namespace.php
@@ -46,7 +46,7 @@ function get_idp_metadata_file_path() : string {
 	}
 
 	// Check for env-specific metadata files.
-	$env_file = Altis\ROOT_DIR . '/.config/sso/' . sprintf( 'saml-idp-metadata-%s.xml', \Altis\get_environment_type() );
+	$env_file = Altis\ROOT_DIR . '/.config/sso/' . sprintf( 'saml-idp-metadata-%s.xml', Altis\get_environment_type() );
 	if ( file_exists( $env_file ) ) {
 		return $env_file;
 	}

--- a/inc/saml/namespace.php
+++ b/inc/saml/namespace.php
@@ -10,6 +10,8 @@ namespace Altis\SSO\SAML;
 use Altis;
 use HumanMade\SimpleSaml;
 
+use function Altis\get_environment_type;
+
 /**
  * Bootstrap SAML integration.
  *
@@ -45,15 +47,21 @@ function get_idp_metadata_file_path() : string {
 		return Altis\ROOT_DIR . DIRECTORY_SEPARATOR . $config['metadata_file'];
 	}
 
+	// Check for env-specific metadata files.
+	$env_file = implode( DIRECTORY_SEPARATOR, [ Altis\ROOT_DIR, '.config', 'sso', sprintf( 'saml-idp-metadata-%s.xml', get_environment_type() ) ] );
+	if ( file_exists( $env_file ) ) {
+		return $env_file;
+	}
+
 	// If the legacy-style file exists, load it, but warn.
-	$legacy_file = Altis\ROOT_DIR . '/config/sso/saml-idp-metadata.xml';
+	$legacy_file = implode( DIRECTORY_SEPARATOR, [ Altis\ROOT_DIR, 'config', 'sso', 'saml-idp-metadata.xml' ] );
 	if ( file_exists( $legacy_file ) ) {
 		trigger_error( 'The default "config/sso/saml-idp-metadata.xml" path is deprecated as of Altis 2.0. Specify the metadata_file setting manually, or use the default ".config/sso/saml-idp-metadata.xml".', E_USER_DEPRECATED );
 		return $legacy_file;
 	}
 
 	// Otherwise, use the default.
-	return Altis\ROOT_DIR . '/.config/sso/saml-idp-metadata.xml';
+	return implode( DIRECTORY_SEPARATOR, [ Altis\ROOT_DIR, '.config', 'sso', 'saml-idp-metadata.xml' ] );
 }
 
 /**


### PR DESCRIPTION
- Updates docs to indicate the need to generate the service provider metadata file
- Updates docs to explain the need for different metadata per environment
- Updates metadata file search logic to detect env-based files based on naming conventions

Fixes #69 