### PR TITLE
Update the minimum PHP version to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		]
 	},
 	"require": {
-		"php": ">=7.1",
+		"php": ">=8.2",
 		"humanmade/wp-simple-saml": "~0.5.1"
 	},
 	"extra": {


### PR DESCRIPTION
Update the minimum PHP version to that which Altis supports. This will allow dependabot to run successfully.

Addresses: humanmade/product-dev#1735