### PR TITLE
Remove v22-branch from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,14 +54,3 @@ updates:
   target-branch: v23-branch
   commit-message:
     prefix: "[v23-branch]"
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v22-branch
-  commit-message:
-    prefix: "[v22-branch]"


### PR DESCRIPTION
The v22 release branch is out of support. Remove the v22-branch
entry from the dependabot configuration.